### PR TITLE
selinux: enable via RKE2_SELINUX envvar

### DIFF
--- a/rpm/centos7/agent/rke2-agent.env
+++ b/rpm/centos7/agent/rke2-agent.env
@@ -1,1 +1,2 @@
 HOME=/root
+RKE2_SELINUX=true

--- a/rpm/centos7/server/rke2-server.env
+++ b/rpm/centos7/server/rke2-server.env
@@ -1,1 +1,2 @@
 HOME=/root
+RKE2_SELINUX=true


### PR DESCRIPTION
Depends on rancher/rke2#173
Addresses rancher/rke2#156

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
