### PR TITLE
Fix sign to use centos:7 instead of 8 due to gpg incompatibility

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,7 +195,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: sign-rpm-centos8-x86_64-amd64
-  image: centos:8
+  image: centos:7
   environment:
     PRIVATE_KEY:
       from_secret: private_key
@@ -285,7 +285,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: sign-rpm-centos8-srcrpm
-  image: centos:8
+  image: centos:7
   environment:
     PRIVATE_KEY:
       from_secret: private_key


### PR DESCRIPTION
Fix sign to use centos:7 instead of 8 due to gpg incompatibility with the sign script

Signed-off-by: Chris Kim <oats87g@gmail.com>