### PR TITLE
Conflict server and agent units

### DIFF
--- a/rpm/centos7/agent/rke2-agent.service
+++ b/rpm/centos7/agent/rke2-agent.service
@@ -3,6 +3,7 @@ Description=Rancher Kubernetes Engine v2 Agent
 Documentation=https://rancher.com
 Wants=network-online.target
 After=network-online.target
+Conflicts=rke2-server.service
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/centos7/server/rke2-server.service
+++ b/rpm/centos7/server/rke2-server.service
@@ -3,6 +3,7 @@ Description=Rancher Kubernetes Engine v2 Server
 Documentation=https://rancher.com
 Wants=network-online.target
 After=network-online.target
+Conflicts=rke2-agent.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This pr adds conflicts for rke2-server and rke2-agent service units. Which by default, starting a rke2-agent service on a node and rke2-server is running, stops the server and runs the agent and vice versa. To avoid running server and agent at the same time.
Issue: https://github.com/rancher/rke2/issues/360