### PR TITLE
Set the keep flag to 100000 so that we keep the last 100,000 RPMs

### DIFF
--- a/rpm/centos7/scripts/upload-repo
+++ b/rpm/centos7/scripts/upload-repo
@@ -69,4 +69,4 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_S3_PATH dist/centos7/$RPMARCH/rke2-*.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_S3_PATH --keep 100000 dist/centos7/$RPMARCH/rke2-*.rpm

--- a/rpm/centos7/scripts/upload-srcrpm-repo
+++ b/rpm/centos7/scripts/upload-srcrpm-repo
@@ -62,4 +62,4 @@ case "$RPM_CHANNEL" in
     ;;
 esac
 
-rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_S3_PATH dist/centos7/source/rke2-*.src.rpm
+rpm-s3 --bucket $AWS_S3_BUCKET -p $TARGET_S3_PATH --keep 100000 dist/centos7/source/rke2-*.src.rpm


### PR DESCRIPTION
This is a "short-term" fix. Long term we likely will want to maintain our own fork of `rpm-s3` that does not implement such hard-logic in it for a keep (that can't even be disabled)

https://github.com/rancher/rke2/issues/386 

Signed-off-by: Chris Kim <oats87g@gmail.com>