### PR TITLE
Prevent rpmbuild from stripping binaries

### DIFF
--- a/rpm/centos7/common/rke2-common.spec
+++ b/rpm/centos7/common/rke2-common.spec
@@ -1,4 +1,5 @@
 %global ARCH.placeholder
+%global __os_install_post %{nil}
 
 Name:    rke2-common
 Version: %{rpm_version}


### PR DESCRIPTION
Configure rke2-common.spec file so rpmbuild does not strip binaries and change checksums

https://github.com/rancher/rke2/issues/496

Signed-off-by: Chris Kim <oats87g@gmail.com>