### PR TITLE
Don't require libseccomp

### DIFF
--- a/rpm/centos7/common/rke2-common.spec
+++ b/rpm/centos7/common/rke2-common.spec
@@ -13,7 +13,6 @@ Source0: https://github.com/rancher/rke2/releases/download/%{rke2_version}/rke2.
 
 BuildRequires: systemd
 Requires(post): rke2-selinux >= %{rke2_policyver}
-Requires: libseccomp >= 2.3
 Requires: iptables
 
 %description


### PR DESCRIPTION
We shouldn't be requiring `libseccomp` as `libseccomp` is statically linked into the `containerd` and corresponding `runc` binaries.

More details are here: https://github.com/rancher/rke2/issues/688