### PR TITLE
Handle CentOS 8 EOL + minor streamline enhancements

### DIFF
--- a/Dockerfile.centos8.dapper
+++ b/Dockerfile.centos8.dapper
@@ -1,6 +1,7 @@
 FROM centos:8
 
-RUN yum install -y epel-release && yum -y install yum-utils rpm-build spectool git jq
+RUN for i in $(ls /etc/yum.repos.d); do sed -i -e "s/mirrorlist.*//g" /etc/yum.repos.d/$i && sed -i -e "s/#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/$i; done && \
+    yum install -y epel-release && yum -y install yum-utils rpm-build spectool git jq
 
 ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT ./dist

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMBARCH ?= x86_64-amd64
-ALL_ARCH = x86_64-amd64 aarch64-arm64
+ALL_ARCH = x86_64-amd64
 
 CENTOS7_TARGETS := $(addprefix centos7-,$(shell ls rpm/centos7/scripts))
 CENTOS8_TARGETS := $(addprefix centos8-,$(shell ls rpm/centos8/scripts))

--- a/rpm/centos7/scripts/version
+++ b/rpm/centos7/scripts/version
@@ -4,7 +4,7 @@ set -x
 # This version script expects either a tag of format: <rke2-version>.<channel>.<rpm-release> or no tag at all.
 
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
-RKE2_FALLBACKVER=v1.18.12+rke2r2
+RKE2_FALLBACKVER=v1.22.6+rke2r1
 
 TREE_STATE=clean
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}

--- a/rpm/centos8/scripts/version
+++ b/rpm/centos8/scripts/version
@@ -4,7 +4,7 @@ set -x
 # This version script expects either a tag of format: <rke2-version>.<channel>.<rpm-release> or no tag at all.
 
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
-RKE2_FALLBACKVER=v1.18.12+rke2r2
+RKE2_FALLBACKVER=v1.22.6+rke2r1
 
 TREE_STATE=clean
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}

--- a/rpm/microos/scripts/version
+++ b/rpm/microos/scripts/version
@@ -4,7 +4,7 @@ set -x
 # This version script expects either a tag of format: <rke2-version>.<channel>.<rpm-release> or no tag at all.
 
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
-RKE2_FALLBACKVER=v1.18.12+rke2r2
+RKE2_FALLBACKVER=v1.22.6+rke2r1
 
 TREE_STATE=clean
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}


### PR DESCRIPTION
https://github.com/rancher/rke2-packaging/issues/21

As stated in the issue, CentOS 8 is no longer maintained/supported and artifacts have moved to vault. We need to continue building RPMs in the interim until a more permanent solution is found.