### PR TITLE
Enable SRC_PATH and TREE_STATE overridable

### DIFF
--- a/rpm/centos7/scripts/build-agent
+++ b/rpm/centos7/scripts/build-agent
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos7/agent/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos7/agent/* "${SRC_PATH}"
 cp -r /source/rpm/centos7/agent/rke2-agent.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-agent.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-agent.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-agent.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -34,8 +33,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-agent.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-agent.spec"
 
 mkdir -p /source/dist/centos7
 mkdir -p /source/dist/centos7/source

--- a/rpm/centos7/scripts/build-common
+++ b/rpm/centos7/scripts/build-common
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos7/common/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos7/common/* "${SRC_PATH}"
 cp -r /source/rpm/centos7/common/rke2-common.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-common.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-common.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-common.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -35,8 +34,8 @@ rpmbuild -vv \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "rke2_policyver ${RKE2_POLICYVER}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-common.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-common.spec"
 
 mkdir -p /source/dist/centos7
 mkdir -p /source/dist/centos7/source

--- a/rpm/centos7/scripts/build-server
+++ b/rpm/centos7/scripts/build-server
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos7/server/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos7/server/* "${SRC_PATH}"
 cp -r /source/rpm/centos7/server/rke2-server.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-server.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-server.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-server.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -34,8 +33,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-server.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-server.spec"
 
 mkdir -p /source/dist/centos7
 mkdir -p /source/dist/centos7/source

--- a/rpm/centos7/scripts/version
+++ b/rpm/centos7/scripts/version
@@ -6,7 +6,7 @@ set -x
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
 RKE2_FALLBACKVER=v1.22.6+rke2r1
 
-TREE_STATE=clean
+TREE_STATE="${TREE_STATE:-clean}"
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}
 TAG=${TAG:-${DRONE_TAG:-$GITHUB_TAG}}
 

--- a/rpm/centos8/scripts/build-agent
+++ b/rpm/centos8/scripts/build-agent
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos8/agent/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos8/agent/* "${SRC_PATH}"
 cp -r /source/rpm/centos8/agent/rke2-agent.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-agent.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-agent.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-agent.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -34,8 +33,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-agent.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-agent.spec"
 
 mkdir -p /source/dist/centos8
 mkdir -p /source/dist/centos8/source

--- a/rpm/centos8/scripts/build-common
+++ b/rpm/centos8/scripts/build-common
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos8/common/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos8/common/* "${SRC_PATH}"
 cp -r /source/rpm/centos8/common/rke2-common.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-common.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-common.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-common.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -35,8 +34,8 @@ rpmbuild -vv \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "rke2_policyver ${RKE2_POLICYVER}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-common.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-common.spec"
 
 mkdir -p /source/dist/centos8
 mkdir -p /source/dist/centos8/source

--- a/rpm/centos8/scripts/build-server
+++ b/rpm/centos8/scripts/build-server
@@ -11,19 +11,18 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/centos8/server/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/centos8/server/* "${SRC_PATH}"
 cp -r /source/rpm/centos8/server/rke2-server.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-server.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-server.spec"
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 spectool -gf rke2-server.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -34,8 +33,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-server.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-server.spec"
 
 mkdir -p /source/dist/centos8
 mkdir -p /source/dist/centos8/source

--- a/rpm/centos8/scripts/version
+++ b/rpm/centos8/scripts/version
@@ -6,7 +6,7 @@ set -x
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
 RKE2_FALLBACKVER=v1.22.6+rke2r1
 
-TREE_STATE=clean
+TREE_STATE="${TREE_STATE:-clean}"
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}
 TAG=${TAG:-${DRONE_TAG:-$GITHUB_TAG}}
 

--- a/rpm/microos/scripts/build-agent
+++ b/rpm/microos/scripts/build-agent
@@ -11,21 +11,20 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/microos/agent/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/microos/agent/* "${SRC_PATH}"
 cp -r /source/rpm/microos/agent/rke2-agent.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-agent.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-agent.spec"
 
-echo "%_topdir /root/rpmbuild" > ~/.rpmmacros
+echo "%_topdir ${HOME}/rpmbuild" >> ~/.rpmmacros
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 rpmdev-spectool -gf rke2-agent.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -36,8 +35,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-agent.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-agent.spec"
 
 ls -R /root/rpmbuild
 

--- a/rpm/microos/scripts/build-common
+++ b/rpm/microos/scripts/build-common
@@ -11,21 +11,20 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/microos/common/* ${SRC_PATH}
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
+
+cp -r /source/rpm/microos/common/* "${SRC_PATH}"
 cp -r /source/rpm/microos/common/rke2-common.spec /root/rpmbuild/SPECS
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-common.spec
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-common.spec"
 
-echo "%_topdir /root/rpmbuild" > ~/.rpmmacros
+echo "%_topdir ${HOME}/rpmbuild" >> ~/.rpmmacros
 
-cd ${SRC_PATH}
+cd "${SRC_PATH}"
 
 rpmdev-spectool -gf rke2-common.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -37,8 +36,8 @@ rpmbuild -vv \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "rke2_policyver ${RKE2_POLICYVER}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-common.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-common.spec"
 
 mkdir -p /source/dist/microos
 mkdir -p /source/dist/microos/source

--- a/rpm/microos/scripts/build-server
+++ b/rpm/microos/scripts/build-server
@@ -11,21 +11,20 @@ fi
 
 IFS=- read RPMARCH GOARCH<<< ${COMBARCH}; unset IFS
 
-mkdir -p "/root/rpmbuild/SPECS"
-
-SRC_PATH="/root/rpmbuild/SOURCES/${RPMARCH}"
-mkdir -p ${SRC_PATH}
-
 HOME=/root
+SRC_PATH="${SRC_PATH:-${HOME}/rpmbuild/SOURCES/${RPMARCH}}"
 
-cp -r /source/rpm/microos/server/* ${SRC_PATH}
-cp -r /source/rpm/microos/server/rke2-server.spec /root/rpmbuild/SPECS
+mkdir -p "/root/rpmbuild/SPECS"
+mkdir -p "${SRC_PATH}"
 
-sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" ${SRC_PATH}/rke2-server.spec
+cp -r /source/rpm/microos/server/* "${SRC_PATH}"
+cp -r /source/rpm/microos/server/rke2-server.spec "${HOME}/rpmbuild/SPECS"
 
-echo "%_topdir /root/rpmbuild" > ~/.rpmmacros
+sed -i "s/\%global ARCH.*/\%global ARCH ${GOARCH}/" "${SRC_PATH}/rke2-server.spec"
 
-cd ${SRC_PATH}
+echo "%_topdir ${HOME}/rpmbuild" >> ~/.rpmmacros
+
+cd "${SRC_PATH}"
 
 rpmdev-spectool -gf rke2-server.spec \
     --define "rke2_version ${RKE2_VERSION}" \
@@ -36,8 +35,8 @@ rpmbuild -vv \
     --define "rke2_version ${RKE2_VERSION}" \
     --define "rpm_release ${RPM_RELEASE}" \
     --define "_sourcedir ${SRC_PATH}" \
-    --target ${RPMARCH} \
-    -ba ${SRC_PATH}/rke2-server.spec
+    --target "${RPMARCH}" \
+    -ba "${SRC_PATH}/rke2-server.spec"
 
 mkdir -p /source/dist/microos
 mkdir -p /source/dist/microos/source

--- a/rpm/microos/scripts/version
+++ b/rpm/microos/scripts/version
@@ -6,7 +6,7 @@ set -x
 RKE2_POLICYVER=0.3-1 #@TODO: Move this to a more global location.
 RKE2_FALLBACKVER=v1.22.6+rke2r1
 
-TREE_STATE=clean
+TREE_STATE="${TREE_STATE:-clean}"
 COMMIT=${COMMIT:-${DRONE_COMMIT:-${GITHUB_SHA:-unknown}}}
 TAG=${TAG:-${DRONE_TAG:-$GITHUB_TAG}}
 


### PR DESCRIPTION
Problem: rke2-packaging build and version scripts will be used on RKE2 CI process ([RKE2#2542](https://github.com/rancher/rke2/pull/2542)) . Currently, some values are overridden through sed replace which is a brittle approach and unmaintainable on the long run

Solution: Enable build scripts to fetch SRC_PATH and TREE_STATE from environment variables

Signed-off-by: Jonnatan Jossemar Cordero <jonnatan.cordero@suse.com>