### PR TITLE
Allow Oracle Linux UEK kernel modules for EL10 RPMs

### DIFF
--- a/rpm/centos8/common/rke2-common.spec
+++ b/rpm/centos8/common/rke2-common.spec
@@ -22,7 +22,7 @@ BuildRequires: systemd
 Requires(post): rke2-selinux >= %{rke2_policyver}
 Requires: iptables
 %if %{require_kernel_extra}
-Requires: kernel-modules-extra%{?_isa}
+Requires: (kernel-modules-extra%{?_isa} or kernel-uek-modules-extra%{?_isa})
 %endif
 
 %description

--- a/rpm/centos8/common/rke2-common.spec
+++ b/rpm/centos8/common/rke2-common.spec
@@ -22,7 +22,7 @@ BuildRequires: systemd
 Requires(post): rke2-selinux >= %{rke2_policyver}
 Requires: iptables
 %if %{require_kernel_extra}
-Requires: (kernel-modules-extra%{?_isa} or kernel-uek-modules-extra%{?_isa})
+Requires: (kernel-modules-extra%{?_isa} or kernel-uek-modules-extra%{?_isa} or kernel-uek64k-modules-extra%{?_isa})
 %endif
 
 %description


### PR DESCRIPTION
### Changes

- Allow EL10 RPMs to satisfy the extra kernel modules dependency with `kernel-modules-extra`, Oracle Linux UEK's `kernel-uek-modules-extra`, or Oracle Linux UEK 64K's `kernel-uek64k-modules-extra`.

### Why

- On Oracle Linux Server 10.1 aarch64 with UEK, the current EL10 RPM cannot be installed because `kernel-modules-extra(aarch-64)` is not provided.

### Validation

- Built `rke2-common` on Oracle Linux Server 10.1 aarch64.
- Verified the generated RPM requires `(kernel-modules-extra(aarch-64) or kernel-uek-modules-extra(aarch-64) or kernel-uek64k-modules-extra(aarch-64))`.
- Verified DNF resolves the generated `rke2-common` RPM when `kernel-uek64k-modules-extra` is installed and `kernel-uek-modules-extra` is not installed.
- Verified DNF resolves the dependency with `kernel-uek-modules-extra` from the OL10 UEK repo.
